### PR TITLE
Fix refreshing of OAuth2 tokens

### DIFF
--- a/auth_gitlab/provider.py
+++ b/auth_gitlab/provider.py
@@ -12,6 +12,8 @@ from .views import FetchUser
 
 class GitLabOAuth2Provider(OAuth2Provider):
     name = 'Gitlab'
+    client_id = CLIENT_ID
+    client_secret = CLIENT_SECRET
 
     def get_auth_pipeline(self):
         return [


### PR DESCRIPTION
This is a copy of https://github.com/SkyLothar/sentry-auth-gitlab/pull/16

Sentry has a background job that checks the state of all OAuth2 identities. If the OAuth2 refresh protocol doesn't work, it marks the identity as needing to reauthenticate. This causes frequent logouts from the Sentry web interface.

This PR allows the refresh protocol to have access to the `CLIENT_ID` and `CLIENT_SECRET` by setting their class properties properly.